### PR TITLE
Filter not including nulls when filtering by optional field

### DIFF
--- a/src/Form/Filter/Type/ComparisonFilterType.php
+++ b/src/Form/Filter/Type/ComparisonFilterType.php
@@ -71,15 +71,23 @@ class ComparisonFilterType extends FilterType
         $paramName = static::createAlias($property);
         $data = $form->getData();
 
-        $orX = new Expr\Orx();
+        if (ComparisonType::NOT_CONTAINS === $data['comparison'] || ComparisonType::NEQ === $data['comparison']) {
+            $queryBuilder->andWhere(
+                $queryBuilder->expr()->orX(
+                    $queryBuilder->expr()->not(
+                        $queryBuilder->expr()->like(sprintf('%s.%s', $alias, $property), sprintf(':%s', $paramName))
+                    ),
+                    $queryBuilder->expr()->isNull(sprintf('%s.%s', $alias, $property))
+                )
+            );
 
-        if (ComparisonType::NOT_CONTAINS === $data['comparison']) {
-            $orX->add(sprintf('%s.%s IS NULL', $alias, $property));
+            $queryBuilder
+                ->setParameter($paramName, $data['value']);
+
+            return;
         }
 
         $queryBuilder->andWhere(sprintf('%s.%s %s :%s', $alias, $property, $data['comparison'], $paramName))
             ->setParameter($paramName, $data['value']);
-
-        $queryBuilder->orWhere($orX);
     }
 }

--- a/src/Form/Filter/Type/ComparisonFilterType.php
+++ b/src/Form/Filter/Type/ComparisonFilterType.php
@@ -71,7 +71,15 @@ class ComparisonFilterType extends FilterType
         $paramName = static::createAlias($property);
         $data = $form->getData();
 
+        $orX = new Expr\Orx();
+
+        if (ComparisonType::NOT_CONTAINS === $data['comparison']) {
+            $orX->add(sprintf('%s.%s IS NULL', $alias, $property));
+        }
+
         $queryBuilder->andWhere(sprintf('%s.%s %s :%s', $alias, $property, $data['comparison'], $paramName))
             ->setParameter($paramName, $data['value']);
+
+        $queryBuilder->orWhere($orX);
     }
 }

--- a/src/Form/Filter/Type/ComparisonFilterType.php
+++ b/src/Form/Filter/Type/ComparisonFilterType.php
@@ -87,6 +87,20 @@ class ComparisonFilterType extends FilterType
             return;
         }
 
+        if (ComparisonType::NEQ === $data['comparison']) {
+            $queryBuilder->andWhere(
+                $queryBuilder->expr()->orX(
+                    $queryBuilder->expr()->neq(sprintf('%s.%s', $alias, $property), sprintf(':%s', $paramName)),
+                    $queryBuilder->expr()->isNull(sprintf('%s.%s', $alias, $property))
+                )
+            );
+
+            $queryBuilder
+                ->setParameter($paramName, $data['value']);
+
+            return;
+        }
+
         $queryBuilder->andWhere(sprintf('%s.%s %s :%s', $alias, $property, $data['comparison'], $paramName))
             ->setParameter($paramName, $data['value']);
     }


### PR DESCRIPTION
[Trello card](https://trello.com/c/kkZVAhYN/3169-el-filtro-por-campo-texto-opcional-con-comparaci%C3%B3n-negativa-no-tiene-en-cuenta-los-nulls)